### PR TITLE
Add experimental support for wasm32-wasi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,9 @@ winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.18", default-features = false }
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+wasi = { version = "0.7", default-features = false }
+
 [target.'cfg(any(unix, windows))'.dev-dependencies]
 libc = { version = "0.2.84", default-features = false }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -272,6 +272,16 @@ mod sysrand_chunk {
     }
 }
 
+#[cfg(all(target_arch = "wasm32", target_os = "wasi",))]
+mod sysrand_chunk {
+    use crate::error;
+    #[inline]
+    pub fn chunk(dest: &mut [u8]) -> Result<usize, error::Unspecified> {
+        wasi::wasi_unstable::random_get(dest).map_err(|_| error::Unspecified)?;
+        Ok(dest.len())
+    }
+}
+
 #[cfg(windows)]
 mod sysrand_chunk {
     use crate::{error, polyfill};


### PR DESCRIPTION
This commit adds the WASI crate and enables conditional compilation
for getting a random number.
This is not tested, and not using the latest version of WASI, so it
should probably not be used in any real world scenario.

Signed-off-by: Radu M <root@radu.sh>